### PR TITLE
Multiple stream fix

### DIFF
--- a/lib/live_stream_async.ex
+++ b/lib/live_stream_async.ex
@@ -70,7 +70,7 @@ defmodule LiveStreamAsync do
     keys = Keyword.keys(opts)
 
     if keys != [] do
-      quote location: :keep, bind_quoted: [keys: keys, opts: opts] do
+      quote do
         def handle_async(key, {:ok, results}, socket) when key in unquote(keys) do
           socket =
             socket


### PR DESCRIPTION
Hello, thank you for this nice utility!

I realized while tinkering with it that options passed to subsequent streams will not be properly reflected in `handle_async`.

Given the following:

```elixir
socket
|> stream_async(:widgets, fn -> Widgets.list() end, limit: 2)
|> stream_async(:trinkets, fn -> Trinkets.list() end, limit: 10)
```

The `unquote(opts)` in `handle_async` will always evaluate as `[limit: 2]`
I believe this has do do with the scope in which it's called, relating to run-time/compile-time nuances I have yet to fully grok, but having tested it, the value of options passed in the first call is always used.

Rather than simply report it, I've created this PR which if not suitable to merge directly, can hopefully provide at least one suggestion on how it might be handled.